### PR TITLE
pass url to $.JSON

### DIFF
--- a/cross-project-dashboard-demo/index.html
+++ b/cross-project-dashboard-demo/index.html
@@ -129,7 +129,7 @@
           if (query) {
             url = url + '&query=' + encodeURIComponent(query)
           }
-          $.getJSON()
+          $.getJSON(url)
             .then(function(results) {
               project.items = results.result.items;
               project.loading = false;


### PR DESCRIPTION
While setting up the application, the results for a project weren't
rendering.

passing url [here](https://github.com/keith-pinto/api-examples/blob/ae1fb1aaf197d0f0f3a7e46d9be31e0914986400/cross-project-dashboard-demo/index.html#L132) got it to work.

Thanks for making this example repo!